### PR TITLE
Fixes for clang

### DIFF
--- a/matching/detail/parentblossom.cpp
+++ b/matching/detail/parentblossom.cpp
@@ -56,7 +56,7 @@ namespace matching
         previousChild = subblossom;
       }
     }
-#define PARENT_BLOSSOM_INSTANTIATION(a) template struct ParentBlossom<a>;
+#define PARENT_BLOSSOM_INSTANTIATION(a) template class ParentBlossom<a>;
     INSTANTIATE_MATCHING_EDGE_WEIGHT_TEMPLATES(PARENT_BLOSSOM_INSTANTIATION)
   }
 }

--- a/swisssystems/dutch.cpp
+++ b/swisssystems/dutch.cpp
@@ -259,7 +259,7 @@ namespace swisssystems
           const std::unordered_map<score_difference, score_difference_shift>
             &scoreDifferenceShifts,
           const tournament::points minScoreInBracket,
-          optimality_matching_computer::edge_weight &maxEdgeWeight =
+          optimality_matching_computer::edge_weight maxEdgeWeight =
             optimality_matching_computer::edge_weight{ 0u })
       {
         typename

--- a/tournament/generator.cpp
+++ b/tournament/generator.cpp
@@ -85,7 +85,7 @@ namespace tournament
     }
 
     template
-    MatchesConfiguration::MatchesConfiguration<std::minstd_rand>(
+    MatchesConfiguration::MatchesConfiguration(
       Configuration &&,
       std::minstd_rand &);
 

--- a/utility/memory.h
+++ b/utility/memory.h
@@ -160,7 +160,7 @@ namespace utility
 
       IterablePoolIterator<T> &operator--() &
       {
-        value = iterablePool.backwardLinks[value - &iterablePool.storage];
+        value = iterablePool->backwardLinks[value - &iterablePool->storage];
         return *this;
       }
       IterablePoolIterator<T> operator--() &&

--- a/utility/uint.h
+++ b/utility/uint.h
@@ -155,7 +155,20 @@ namespace utility
         result <<= shift;
         return result;
       }
+
+      constexpr uint<pieces> operator<<(unsigned long shift) const
+      {
+        uint<pieces> result = *this;
+        result <<= shift;
+        return result;
+      }
       constexpr uint<pieces> operator>>(const unsigned int shift) const
+      {
+        uint<pieces> result = *this;
+        result >>= shift;
+        return result;
+      }
+      constexpr uint<pieces> operator>>(int shift) const
       {
         uint<pieces> result = *this;
         result >>= shift;
@@ -943,8 +956,8 @@ namespace utility
         return
           value0 * value1.lowPieces
             + (value0 * value1.highPiece
-                << std::numeric_limits<std::uintmax_t>::digits
-                    * (pieces1 - 1u));
+                << (std::numeric_limits<std::uintmax_t>::digits
+                    * (pieces1 - 1u)));
       }
     }
     template <

--- a/utility/uint.h
+++ b/utility/uint.h
@@ -947,7 +947,10 @@ namespace utility
                     * (pieces1 - 1u));
       }
     }
-    template <std::size_t pieces, typename T>
+    template <
+      std::size_t pieces,
+      typename T,
+      typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
     constexpr detail::preferred_type<pieces, T>
       operator*(const T value0, const uint<pieces> value1)
     {


### PR DESCRIPTION
While trying to get bbpPairings to work on macOS, I stumbeld upon several compiler errors. The changes in this PR should be enough to satisfy clang.

Note: to compile bbpPairings on macOS more changes are needed.