### PR TITLE
Add compilation to JavaScript/WebAssembly via emcc by Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,11 @@ endif
 
 ifeq ($(profile),yes)
 	optional_cxxflags += -ggdb
-	optional_cxxflags += -O3
+	ifeq ($(COMP),emcc)
+		optional_cxxflags += -Os
+	else
+		optional_cxxflags += -O3
+	endif
 	ifneq ($(debug),yes)
 		optional_cxxflags += -DNDEBUG
 	endif
@@ -144,7 +148,11 @@ else
 		optional_cxxflags += -DNDEBUG
 		optional_ldflags += -s
 		ifeq ($(optimize),yes)
-			optional_cxxflags += -O3
+			ifeq ($(COMP),emcc)
+				optional_cxxflags += -Os
+			else
+				optional_cxxflags += -O3
+			endif
 		endif
 	endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,12 @@ ifeq ($(COMP),clang)
 	# -Wweak-template-vtables
 	# -Wweak-vtables
 endif
+ifeq ($(COMP),emcc)
+	CXX=emcc
+	optional_cxxflags += \
+		-Wno-uninitialized \
+		-Wsometimes-uninitialized
+endif
 
 CXXFLAGS = $(optional_cxxflags)
 
@@ -424,6 +430,11 @@ $(OBJ)/bbpPairings.exe: $(OBJECTS)
 
 bbpPairings.exe: $(OBJ)/bbpPairings.exe
 	cp $(OBJ)/bbpPairings.exe $@
+ifeq ($(COMP),emcc)
+	cp $(OBJ)/bbpPairings.wasm bbpPairings.wasm
+	sed -i '1i#!/usr/bin/env node' $@
+	chmod +x $@
+endif
 
 -include $(OBJECTS:%.o=%.d)
 

--- a/Makefile
+++ b/Makefile
@@ -402,8 +402,7 @@ ifeq ($(COMP),emcc)
 		-Wno-uninitialized \
 		-Wsometimes-uninitialized
 	optional_ldflags += \
-		-sMALLOC=emmalloc \
-		-sFILESYSTEM=0
+		-sMALLOC=emmalloc
 endif
 
 CXXFLAGS = $(optional_cxxflags)

--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,9 @@ ifeq ($(COMP),emcc)
 	optional_cxxflags += \
 		-Wno-uninitialized \
 		-Wsometimes-uninitialized
+	optional_ldflags += \
+		-sMALLOC=emmalloc \
+		-sFILESYSTEM=0
 endif
 
 CXXFLAGS = $(optional_cxxflags)


### PR DESCRIPTION
With [*emscripten*](https://emscripten.org/) it is possible to compile C++ to JavaScript and WebAssembly. This way, bbpPairings can be used offline in the browser and in server-side JavaScript environments like node.js. I managed to successfully compile bbpPairings to JS+WASM with a newly added `make COMP=emcc`. File sizes are looking good:

```sh
> ls -lh bbpPairings*
-rwxrwxr-x 1 fnogatz fnogatz  74K Apr 18 10:25 bbpPairings.exe
-rwxrwxr-x 1 fnogatz fnogatz 397K Apr 18 10:25 bbpPairings.wasm
> ./bbpPairings.exe -h
BBP Pairings (https://github.com/BieremaBoyzProgramming/bbpPairings) - non-release build v4.1.0-34-g7df02ca (Built Apr 18 2022 10:25:10)

Command line argument syntax:
bbpPairings.exe [-r]
bbpPairings.exe [-r] (--dutch | --burstein) input-file -c [-l [check-list-file]]
bbpPairings.exe [-r] (--dutch | --burstein) input-file -p [output-file] [-l [check-list-file]]
bbpPairings.exe [-r] (--dutch | --burstein) (model-file -g | -g [config-file]) -o trf_file [-s random_seed] [-l [check-list-file]]
```

The emcc-compiled files behave the same as the traditionally compiled ones, but require `node` to be installed.

Note that though emscripten allows to build [with filesystem support](https://emscripten.org/docs/api_reference/Filesystem-API.html), I instead suggest to simply rely on stdin and stdout to keep the generated file sizes small. Therefore, this PR emphasises to also allow to provide TRF files via stdin, as proposed in #12.