### PR TITLE
Fix Makefile dependency handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ clean: clean-tests
 
 $(OBJ)/%.o: $(SRC)/%.cpp
 	mkdir -p $(dir $@)
-	$(CXX) -o $@ $^ -c -I$(SRC) -MMD -MP $(CXXFLAGS)
+	$(CXX) -o $@ $(filter %.cpp,$^) -c -I$(SRC) -MMD -MP -MT $@ -MT $(@:%.o=%.d) $(CXXFLAGS)
 
 $(OBJ)/bbpPairings.exe: $(OBJECTS)
 	$(CXX) -o $@ $(OBJECTS) $(LDFLAGS)


### PR DESCRIPTION
To get some nice errors, do this:

```
$ make
$ touch src/main.cpp
$ make
```

A couple of issues.

```makefile
SRC = src
OBJ = build
SOURCES = $(shell find $(SRC) -name "*.cpp")
OBJECTS = $(patsubst $(SRC)/%.cpp, $(OBJ)/%.o, $(SOURCES))
# ...
$(OBJ)/%.o: $(SRC)/%.cpp
	mkdir -p $(dir $@)
	$(CXX) -o $@ $^ -c -I$(SRC) -MMD -MP $(CXXFLAGS)
# ...
-include $(OBJECTS:%.o=%.d)
```

The first time make is invoked, as expected, we get the single cpp in `$^`. But that recipe has the side-effect of creating a `build/%.d` for every `src/%.cpp` and these will get included at the second invocation.

So the second time the recipe is entered we get all the autogen'd dependencies, not just the `$(SRC)/%.cpp`. We can't compile the headers and have to guard against that, either by using `$<` instead of `$^` (the dependencies are in a sane order, and usually we compile one source to one object file) or with a filter (just in case).

The other issue is that the the `*.d` files themselves needed to get updated whenever a source changes (i.e. when adding or removing includes).

Also that patsubst could be rewritten like the one in the include line.