### PR TITLE
fix: TRF26 line "162" parsing

### DIFF
--- a/src/fileformats/trf.cpp
+++ b/src/fileformats/trf.cpp
@@ -605,7 +605,7 @@ namespace fileformats
           {
             tournament.pointsForLoss = score;
           }
-          else if (resultChar == U'A')
+          else if (resultChar == U'Z' || resultChar == U'A')
           {
             tournament.pointsForZeroPointBye = score;
             tournament.pointsForForfeitLoss = score;

--- a/src/fileformats/trf.cpp
+++ b/src/fileformats/trf.cpp
@@ -605,7 +605,7 @@ namespace fileformats
           {
             tournament.pointsForLoss = score;
           }
-          else if (resultChar == U'Z')
+          else if (resultChar == U'A')
           {
             tournament.pointsForZeroPointBye = score;
             tournament.pointsForForfeitLoss = score;


### PR DESCRIPTION
According to [TRF26](http://tec.fide.com/wp-content/uploads/2025/04/TRF-2026.pdf) line "162" defines absence (zero-point-bye or forfeit loss) as "A" (not "Z").
It's even used correctly in [writeFile](https://github.com/BieremaBoyzProgramming/bbpPairings/blob/7dca5c007148505a3dd35ed37b6e7581b7937a3e/src/fileformats/trf.cpp#L1481)
